### PR TITLE
Allow optional space after the shebang

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function (str) {
 		return null;
 	}
 
-	var arr = match[0].replace('#!', '').split(' ');
+	var arr = match[0].replace(/#! ?/, '').split(' ');
 	var bin = arr[0].split('/').pop();
 
 	return bin === 'env' ? arr[1] : bin;

--- a/test.js
+++ b/test.js
@@ -5,5 +5,6 @@ test(t => {
 	t.is(fn('#!/usr/bin/env node'), 'node');
 	t.is(fn('#!/bin/bash'), 'bash');
 	t.is(fn('#!/sh'), 'sh');
+	t.is(fn('#! /bin/bash'), 'bash');
 	t.is(fn('node'), null);
 });


### PR DESCRIPTION
Hi,

I’ve always written shebangs with a space after the `#!` – makes the thing a bit more readable. It’s always worked and [Wikipedia says](https://en.wikipedia.org/wiki/Shebang_%28Unix%29) it’s ok.
