### PR TITLE
remove shebang-regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 'use strict';
-var shebangRegex = require('shebang-regex');
 
 module.exports = function (str) {
-	var match = str.match(shebangRegex);
+	var match = str.match(/^#!(.*)/);
 
 	if (!match) {
 		return null;

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
 		"parse",
 		"shebang"
 	],
-	"dependencies": {
-		"shebang-regex": "^1.0.0"
-	},
 	"devDependencies": {
 		"ava": "^0.17.0",
 		"xo": "^0.16.0"


### PR DESCRIPTION
Hello,

The actual shebang regex is 9 characters long, the import syntaxe is **longer** than the actual regex and the package also contains a license, a package.json file, a readme and a type definition file !
The package is 2 828 bytes while the regex is only 9 bytes, it is **314** times bigger than the regex.

shebang-command has 9 223 330 weekly downloads, if we remove the package we can save 26 000 567 270 bytes (More than 2,6 Gb) bytes of useless files.

Also more packages means more risk, here's an article talking about it :  
[I’m harvesting credit card numbers and passwords from your site. Here’s how.](https://medium.com/hackernoon/im-harvesting-credit-card-numbers-and-passwords-from-your-site-here-s-how-9a8cb347c5b5)

An incident has already happened this year with the package event-stream  :
[Malicious code found in npm package event-stream downloaded 8 million times in the past 2.5 months](https://snyk.io/blog/malicious-code-found-in-npm-package-event-stream/)